### PR TITLE
GPIO blinds device

### DIFF
--- a/docs/How to build vdcd (and vdsm) on Linux - in particular Raspian on P44-DSB-X.md
+++ b/docs/How to build vdcd (and vdsm) on Linux - in particular Raspian on P44-DSB-X.md
@@ -44,7 +44,7 @@ Now the platform is ready to install & build!
 	$SUPER apt-get update
 	
 	# build tools
-	$SUPER apt-get install git automake libtool autoconf g++
+	$SUPER apt-get install git automake libtool autoconf g++ make
 
 	# common libraries for both vdcd and vdsm
 	$SUPER apt-get install libjson0-dev libsqlite3-dev protobuf-c-compiler libprotobuf-c0-dev

--- a/src/behaviours/shadowbehaviour.cpp
+++ b/src/behaviours/shadowbehaviour.cpp
@@ -127,8 +127,24 @@ void ShadowScene::setDefaultSceneValues(SceneNo aSceneNo)
     case SIG_PANIC:
     case SMOKE:
     case HAIL:
-      // Panic, Smoke, Hail: open
+    case FIRE:
+      // Panic, Smoke, Hail, Fire: open
+      setDontCare(false);
       value = 100;
+      break;
+    case ABSENT:
+    case PRESENT:
+    case SLEEPING:
+    case WAKE_UP:
+    case STANDBY:
+    case AUTO_STANDBY:
+    case DEEP_OFF:
+    case ALARM1:
+    case WATER:
+    case GAS:
+    case WIND:
+    case RAIN:
+      setDontCare(true);
       break;
     case T0_S2:
     case T1_S2:
@@ -149,6 +165,58 @@ void ShadowScene::setDefaultSceneValues(SceneNo aSceneNo)
 }
 
 
+#pragma mark - ShadowJalousieScene
+
+
+ShadowJalousieScene::ShadowJalousieScene(SceneDeviceSettings &aSceneDeviceSettings, SceneNo aSceneNo) :
+inherited(aSceneDeviceSettings, aSceneNo)
+{
+}
+
+
+void ShadowJalousieScene::setDefaultSceneValues(SceneNo aSceneNo)
+{
+  // set the common simple scene defaults
+  inherited::setDefaultSceneValues(aSceneNo);
+  // Add special shadow behaviour
+  switch (aSceneNo) {
+    case WIND:
+      setDontCare(false);
+      value = 100;
+      break;
+  }
+  markClean(); // default values are always clean (but setSceneValueFlags sets dirty)
+}
+
+
+#pragma mark - ShadowJalousieScene
+
+
+ShadowAwningScene::ShadowAwningScene(SceneDeviceSettings &aSceneDeviceSettings, SceneNo aSceneNo) :
+inherited(aSceneDeviceSettings, aSceneNo)
+{
+}
+
+
+void ShadowAwningScene::setDefaultSceneValues(SceneNo aSceneNo)
+{
+  // set the common simple scene defaults
+  inherited::setDefaultSceneValues(aSceneNo);
+  // Add special shadow behaviour
+  switch (aSceneNo) {
+    case ABSENT:
+    case SLEEPING:
+    case DEEP_OFF:
+    case WIND:
+    case RAIN:
+      setDontCare(false);
+      value = 100;
+      break;
+  }
+  markClean(); // default values are always clean (but setSceneValueFlags sets dirty)
+}
+
+
 #pragma mark - ShadowDeviceSettings with default shadow scenes factory
 
 
@@ -164,6 +232,42 @@ DsScenePtr ShadowDeviceSettings::newDefaultScene(SceneNo aSceneNo)
   shadowScene->setDefaultSceneValues(aSceneNo);
   // return it
   return shadowScene;
+}
+
+
+#pragma mark - ShadowJalousieDeviceSetting with default shadow scenes factory
+
+
+ShadowJalousieDeviceSetting::ShadowJalousieDeviceSetting(Device &aDevice) :
+inherited(aDevice)
+{
+};
+
+
+DsScenePtr ShadowJalousieDeviceSetting::newDefaultScene(SceneNo aSceneNo)
+{
+  ShadowJalousieScenePtr shadowJalousieScene = ShadowJalousieScenePtr(new ShadowJalousieScene(*this, aSceneNo));
+  shadowJalousieScene->setDefaultSceneValues(aSceneNo);
+  // return it
+  return shadowJalousieScene;
+}
+
+
+#pragma mark - ShadowJalousieDeviceSetting with default shadow scenes factory
+
+
+ShadowAwningDeviceSetting::ShadowAwningDeviceSetting(Device &aDevice) :
+inherited(aDevice)
+{
+};
+
+
+DsScenePtr ShadowAwningDeviceSetting::newDefaultScene(SceneNo aSceneNo)
+{
+  ShadowAwningScenePtr shadowAwningScene = ShadowAwningScenePtr(new ShadowAwningScene(*this, aSceneNo));
+  shadowAwningScene->setDefaultSceneValues(aSceneNo);
+  // return it
+  return shadowAwningScene;
 }
 
 

--- a/src/behaviours/shadowbehaviour.cpp
+++ b/src/behaviours/shadowbehaviour.cpp
@@ -676,21 +676,6 @@ void ShadowBehaviour::movePaused(MLMicroSeconds aRemainingMoveTime, SimpleCB aAp
 #pragma mark - behaviour interaction with digitalSTROM system
 
 
-// apply scene
-bool ShadowBehaviour::applyScene(DsScenePtr aScene)
-{
-  // check special cases for shadow scenes
-  ShadowScenePtr shadowScene = boost::dynamic_pointer_cast<ShadowScene>(aScene);
-  if (shadowScene) {
-    // any scene call cancels actions (and fade down)
-    stopActions();
-  } // if shadowScene
-  // otherwise, let base class handle it
-  return inherited::applyScene(aScene);
-}
-
-
-
 void ShadowBehaviour::loadChannelsFromScene(DsScenePtr aScene)
 {
   ShadowScenePtr shadowScene = boost::dynamic_pointer_cast<ShadowScene>(aScene);

--- a/src/behaviours/shadowbehaviour.cpp
+++ b/src/behaviours/shadowbehaviour.cpp
@@ -603,7 +603,7 @@ void ShadowBehaviour::applyPosition(SimpleCB aApplyDoneCB)
       // fully down, always do full cycle to synchronize position
       dist = -120; // 20% extra to fully run into end switch
       runIntoEnd = true; // if we have end switches, let them stop the movement
-      if (referencePosition>=0) updateMoveTimeAtEndReached = true; // full range movement, use it to update movement time
+      if (referencePosition>=100) updateMoveTimeAtEndReached = true; // full range movement, use it to update movement time
     }
     else {
       // somewhere in between, actually estimate distance

--- a/src/behaviours/shadowbehaviour.hpp
+++ b/src/behaviours/shadowbehaviour.hpp
@@ -116,6 +116,38 @@ namespace p44 {
 
   };
   typedef boost::intrusive_ptr<ShadowScene> ShadowScenePtr;
+  
+  
+  
+  class ShadowJalousieScene : public ShadowScene
+  {
+    typedef ShadowScene inherited;
+    
+  public:
+    ShadowJalousieScene(SceneDeviceSettings &aSceneDeviceSettings, SceneNo aSceneNo); ///< constructor, sets values according to dS specs' default values
+
+    /// Set default scene values for a specified scene number
+    /// @param aSceneNo the scene number to set default values
+    virtual void setDefaultSceneValues(SceneNo aSceneNo);
+    
+  };
+  typedef boost::intrusive_ptr<ShadowJalousieScene> ShadowJalousieScenePtr;
+  
+  
+  
+  class ShadowAwningScene : public ShadowScene
+  {
+    typedef ShadowScene inherited;
+    
+  public:
+    ShadowAwningScene(SceneDeviceSettings &aSceneDeviceSettings, SceneNo aSceneNo); ///< constructor, sets values according to dS specs' default values
+    
+    /// Set default scene values for a specified scene number
+    /// @param aSceneNo the scene number to set default values
+    virtual void setDefaultSceneValues(SceneNo aSceneNo);
+    
+  };
+  typedef boost::intrusive_ptr<ShadowAwningScene> ShadowAwningScenePtr;
 
 
 
@@ -132,6 +164,36 @@ namespace p44 {
     /// @note setDefaultSceneValues() must be called to set default scene values
     virtual DsScenePtr newDefaultScene(SceneNo aSceneNo);
 
+  };
+    
+    
+    
+  class ShadowJalousieDeviceSetting : public ShadowDeviceSettings
+  {
+    typedef ShadowDeviceSettings inherited;
+
+  public:
+    ShadowJalousieDeviceSetting(Device &aDevice);
+
+    /// factory method to create the correct subclass type of DsScene
+    /// @param aSceneNo the scene number to create a scene object for.
+    /// @note setDefaultSceneValues() must be called to set default scene values
+    virtual DsScenePtr newDefaultScene(SceneNo aSceneNo);
+  };
+  
+  
+  
+  class ShadowAwningDeviceSetting : public ShadowDeviceSettings
+  {
+    typedef ShadowDeviceSettings inherited;
+    
+  public:
+    ShadowAwningDeviceSetting(Device &aDevice);
+    
+    /// factory method to create the correct subclass type of DsScene
+    /// @param aSceneNo the scene number to create a scene object for.
+    /// @note setDefaultSceneValues() must be called to set default scene values
+    virtual DsScenePtr newDefaultScene(SceneNo aSceneNo);
   };
 
 

--- a/src/behaviours/shadowbehaviour.hpp
+++ b/src/behaviours/shadowbehaviour.hpp
@@ -260,14 +260,6 @@ namespace p44 {
     /// @return yes if this output behaviour has the feature, no if (explicitly) not, undefined if asked entity does not know
     virtual Tristate hasModelFeature(DsModelFeatures aFeatureIndex);
 
-    /// apply scene to output channels
-    /// @param aScene the scene to apply to output channels
-    /// @return true if apply is complete, i.e. everything ready to apply to hardware outputs.
-    ///   false if scene cannot yet be applied to hardware, and will be performed later
-    /// @note this derived class' applyScene only implements special hard-wired behaviour specific scenes
-    ///   basic scene apply functionality is provided by base class' implementation already.
-    virtual bool applyScene(DsScenePtr aScene);
-
     /// perform special scene actions (like flashing) which are independent of dontCare flag.
     /// @param aScene the scene that was called (if not dontCare, applyScene() has already been called)
     /// @param aDoneCB will be called when scene actions have completed (but not necessarily when stopped by stopActions())

--- a/src/deviceclasses/simpleio/digitaliodevice.hpp
+++ b/src/deviceclasses/simpleio/digitaliodevice.hpp
@@ -44,12 +44,15 @@ namespace p44 {
       digitalio_input, // binary input
       digitalio_light, // light output
       digitalio_relay, // general purpose relay output
+      digitalio_blind, // blind output
     } DigitalIoType;
 
 
 		ButtonInputPtr buttonInput;
     DigitalIoPtr digitalInput;
     IndicatorOutputPtr indicatorOutput;
+    DigitalIoPtr blindsOutputUp;
+    DigitalIoPtr blindsOutputDown;
 
     DigitalIoType digitalIoType;
 
@@ -67,6 +70,8 @@ namespace p44 {
     /// Get extra info (plan44 specific) to describe the addressable in more detail
     /// @return string, single line extra info describing aspects of the device not visible elsewhere
     virtual string getExtraInfo();
+      
+    virtual void dimChannel(DsChannelType aChannelType, DsDimMode aDimMode);
 
     /// @name interaction with subclasses, actually representing physical I/O
     /// @{
@@ -79,6 +84,15 @@ namespace p44 {
     /// @param aForDimming hint for implementations to optimize dimming, indicating that change is only an increment/decrement
     ///   in a single channel (and not switching between color modes etc.)
     virtual void applyChannelValues(SimpleCB aDoneCB, bool aForDimming);
+      
+    /// synchronize channel values by reading them back from the device's hardware (if possible)
+    /// @param aDoneCB will be called when values are updated with actual hardware values
+    /// @note this method is only called at startup and before saving scenes to make sure changes done to the outputs directly (e.g. using
+    ///   a direct remote control for a lamp) are included. Just reading a channel state does not call this method.
+    /// @note implementation must use channel's syncChannelValue() method
+    virtual void syncChannelValues(SimpleCB aDoneCB);
+    
+    void changeMovement(SimpleCB aDoneCB, int aNewDirection);
 
     /// @}
 
@@ -99,6 +113,7 @@ namespace p44 {
 
     void buttonHandler(bool aNewState, MLMicroSeconds aTimestamp);
     void inputHandler(bool aNewState);
+    string blindsName() const;
 
   };
 


### PR DESCRIPTION
Implements a blinds devices with two GPIOs (up/down)

Configuration string: gpio.9;gpio.10:blind

Known issues:
- no way of configuring blinds runtimes
- directly setting "%" from the dSS does not work
